### PR TITLE
Fix markdown link syntax to primer.

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -19,7 +19,7 @@
 ## Can you help me with some things?
 
 Maybe? 
-Try checking out [~pfhawkins' Tilde Tips and Tricks page](http://tilde.club/~pfhawkins/tipsntricks.html). It's useful. He also suggests [~anthonydpaul's primer] (http://tilde.club/~anthonydpaul/primer.html).
+Try checking out [~pfhawkins' Tilde Tips and Tricks page](http://tilde.club/~pfhawkins/tipsntricks.html). It's useful. He also suggests [~anthonydpaul's primer](http://tilde.club/~anthonydpaul/primer.html).
 For other stuff you might want in the FAQ drop us a note to ~faq.
 
 ## What else? Not much for now.


### PR DESCRIPTION
There was a space between the ] and the (, causing markdown to not make it a link.
