### PR TITLE
Kicking off the netiquette file

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -37,6 +37,9 @@ Tilde has a great community culture and we're trying hard to keep it that way. W
 - [Github](https://github.com/tildeclub/tilde.club)
 - [Webring](http://tilde.club/~harper/link.html?action=join) 
 - [Skillswap](http://goo.gl/forms/LT2bDgtmwH)
+- [Unofficial API](http://tilde.club/~danielbachhuber/club-sites.json)
+- [More API](http://tilde.club/~gabriel/who.json)
+
 
 We can't wait to meet you.
  

--- a/netiquette.md
+++ b/netiquette.md
@@ -1,4 +1,98 @@
+#TILDE.CLUB FAQ
 
-# NETIQUETTE
+------------------------------------------------------------
+* WHAT IS THIS?
 
-Coming soon. We should have one, but let's discuss how to link to it.
+It is a UNIX server just like we used to use to host websites in 1995.
+
+------------------------------------------------------------
+* HOW MANY PEOPLE WILL BE ON THE SYSTEM?
+
+A couple hundred. Otherwise it's ridiculous.
+
+------------------------------------------------------------
+* CAN I HAVE A LOGIN?
+
+Until there are a couple hundred people, it's pretty open.
+
+------------------------------------------------------------
+* WHAT ARE THE STANDARDS OF BEHAVIOR?
+
+Be as much of a nerd as you want. Don't make other users uncomfortable
+by talking about wangs and stuff. I'm old and cranky and I'll boot
+you.
+
+------------------------------------------------------------
+* CAN I...
+
+ACTUALLY...go easy. There are a few hundred people on this 
+box so it gets a little overwhelmed at times.
+
+------------------------------------------------------------
+* CAN I HOST .AIFF FILES AND THINGS?
+
+No, my god. This is a fun place to play not a place to download
+Fractal Design Poser 3.
+
+------------------------------------------------------------
+* WHERE IS THE API?
+
+There is an unofficial API for this unofficial site at:
+http://tilde.club/~danielbachhuber/club-sites.json
+
+There is more API at:
+http://tilde.club/~gabriel/who.json
+
+
+NEW USER TUTORIAL
+
+tilde.club is just a tiny tiny server running linux on the amazon
+cloud. Using tilde.club requires you to understand shells and ssh. If
+you don't know about those things, consider this a challenge and
+opportunity to learn! This concludes the tutorial.
+
+IMPORTANT NOTES
+
+Since I've now saddled myself in this clown rodeo, a few notes:
+
+- No drama. What constitutes drama? There is a Mary J. Blige song
+  called "No More Drama." If Mary J. Blige would think it was drama,
+  it is drama.
+
+- vim AND emacs are installed, use the one that is right for you. See
+  "No drama," above.
+
+- Chat with anyone you want using the talk command (ytalk seems to
+  have gone missing from the Internet!). Just amuse yourself by
+  pinging people and saying stuff at random. Don't be shy. If they
+  bail or don't reply no worries. This is a unix server. The only
+  people who want free accounts on unix servers are awesome cool
+  loving generous nerds.
+
+- If you don't want to chat there's a command that lets you indicate
+  that. See if you can remember that command!
+
+- This is a guilt-free project and total disaster is ALWAYS a possible
+  outcome. I'll cover costs up to about $100 a month. I doubt I'll let
+  more than a hundred or two hundred people on the system because
+  randos ruin. There are a hundred people now.
+
+- This thing is a de-facto whitey sausagefest so everyone be actively,
+  aggressively cool and sweet and remember that the only binary that's
+  real is the one that we use on our microchips.
+
+MY SACRED VOWS TO YOU
+
+I will do my best to do the following things:
+
+1) I will make a weekly backup of the public_html directories so when
+some teen in Estonia decides to hack in and ruin everything we can
+bring up a new server and limp back to life.
+
+2) I won't shut things down without a month of warning and once it's
+shut down I'll make sure a file with all the public_html directories
+is uploaded to archive.org.
+
+3) If any community forms at all (DUBIOUS BUT SURPRISE ME) I promise I
+won't blow up the community without, like, first pointing everyone to
+some free IRC channel or something.

--- a/netiquette.md
+++ b/netiquette.md
@@ -1,87 +1,19 @@
-#TILDE.CLUB FAQ
+#Tilde.club netiquette
 
-------------------------------------------------------------
-* WHAT IS THIS?
+##Two phrases we use a lot
 
-It is a UNIX server just like we used to use to host websites in 1995.
+* DON'T HACK THE GIBSON
+* No drama. Be respectful. Have fun. We're all trying, and we're all in this together :)
 
-------------------------------------------------------------
-* HOW MANY PEOPLE WILL BE ON THE SYSTEM?
+##Details
 
-A couple hundred. Otherwise it's ridiculous.
+First things first, explore and have fun! But remember, this is a single linux server trying to support the weight of several hundred nerds. Don't host servers, don't run heavy processes, don't host giant files. In short, be gentle. 
 
-------------------------------------------------------------
-* CAN I HAVE A LOGIN?
+More about [scripting netiquette here](http://tilde.club/#WHEREISTHIS)
 
-Until there are a couple hundred people, it's pretty open.
+Now let's talk about drama. There is a Mary J. Blige song called "No More Drama." If Mary J. Blige would think it was drama, it is drama. No flamewars about emacs/vi, no matter how historically accurate they may be. No guilting people, shaming them, or making them feel bad. More benefit of the doubt and less "are you kidding me?"
 
-------------------------------------------------------------
-* WHAT ARE THE STANDARDS OF BEHAVIOR?
-
-Be as much of a nerd as you want. Don't make other users uncomfortable
-by talking about wangs and stuff. I'm old and cranky and I'll boot
-you.
-
-------------------------------------------------------------
-* CAN I...
-
-ACTUALLY...go easy. There are a few hundred people on this 
-box so it gets a little overwhelmed at times.
-
-------------------------------------------------------------
-* CAN I HOST .AIFF FILES AND THINGS?
-
-No, my god. This is a fun place to play not a place to download
-Fractal Design Poser 3.
-
-------------------------------------------------------------
-* WHERE IS THE API?
-
-There is an unofficial API for this unofficial site at:
-http://tilde.club/~danielbachhuber/club-sites.json
-
-There is more API at:
-http://tilde.club/~gabriel/who.json
-
-
-NEW USER TUTORIAL
-
-tilde.club is just a tiny tiny server running linux on the amazon
-cloud. Using tilde.club requires you to understand shells and ssh. If
-you don't know about those things, consider this a challenge and
-opportunity to learn! This concludes the tutorial.
-
-IMPORTANT NOTES
-
-Since I've now saddled myself in this clown rodeo, a few notes:
-
-- No drama. What constitutes drama? There is a Mary J. Blige song
-  called "No More Drama." If Mary J. Blige would think it was drama,
-  it is drama.
-
-- vim AND emacs are installed, use the one that is right for you. See
-  "No drama," above.
-
-- Chat with anyone you want using the talk command (ytalk seems to
-  have gone missing from the Internet!). Just amuse yourself by
-  pinging people and saying stuff at random. Don't be shy. If they
-  bail or don't reply no worries. This is a unix server. The only
-  people who want free accounts on unix servers are awesome cool
-  loving generous nerds.
-
-- If you don't want to chat there's a command that lets you indicate
-  that. See if you can remember that command!
-
-- This is a guilt-free project and total disaster is ALWAYS a possible
-  outcome. I'll cover costs up to about $100 a month. I doubt I'll let
-  more than a hundred or two hundred people on the system because
-  randos ruin. There are a hundred people now.
-
-- This thing is a de-facto whitey sausagefest so everyone be actively,
-  aggressively cool and sweet and remember that the only binary that's
-  real is the one that we use on our microchips.
-
-MY SACRED VOWS TO YOU
+##~ford's SACRED VOWS to the community
 
 I will do my best to do the following things:
 


### PR DESCRIPTION
If you type "faq" at the command line, you see a lot of great content from @ftrain. @jessamynwest and I discussed perhaps dividing the culture stuff ("no guilt") from the frequently asked questions stuff ("how do I ...") and that's how we've ended up here. Two documents, faq and netiquette.

Happy to hear suggestions for improving this page, plus we need a few links added:

1) We need to link to the scripting netiquette doc
2) We need to link FAQ to netiquette somehow. We're currently thinking netiquette can just live in the ~faq/ directory.
